### PR TITLE
Fix default tag parsing

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -310,7 +310,10 @@ func (o tagOptions) Contains(option string) bool {
 func (o tagOptions) getDefaultOptionValue() string {
 	for _, s := range o {
 		if strings.HasPrefix(s, "default:") {
-			return strings.Split(s, ":")[1]
+			if parts := strings.SplitN(s, ":", 2); len(parts) == 2 {
+				return parts[1]
+			}
+			return ""
 		}
 	}
 

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -2456,6 +2456,22 @@ func TestDefaultsAreNotSupportedForStructsAndStructSlices(t *testing.T) {
 	}
 }
 
+func TestDefaultValueWithColon(t *testing.T) {
+	type D struct {
+		URL string `schema:"url,default:http://localhost:8080"`
+	}
+
+	var d D
+	decoder := NewDecoder()
+	if err := decoder.Decode(&d, map[string][]string{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if d.URL != "http://localhost:8080" {
+		t.Errorf("expected default url to be http://localhost:8080, got %s", d.URL)
+	}
+}
+
 func TestDecoder_MaxSize(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- handle colons in default tag values
- add test for defaults containing colons

## Testing
- `go test ./...`
