### PR TITLE
Implement parser index limit

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -12,7 +12,12 @@ import (
 	"sync"
 )
 
-var errInvalidPath = errors.New("schema: invalid path")
+const maxParserIndex = 1000
+
+var (
+	errInvalidPath   = errors.New("schema: invalid path")
+	errIndexTooLarge = errors.New("schema: index exceeds parser limit")
+)
 
 // newCache returns a new cache.
 func newCache() *cache {
@@ -77,6 +82,9 @@ func (c *cache) parsePath(p string, t reflect.Type) ([]pathPart, error) {
 			}
 			if index64, err = strconv.ParseInt(keys[i], 10, 0); err != nil {
 				return nil, errInvalidPath
+			}
+			if index64 > maxParserIndex {
+				return nil, errIndexTooLarge
 			}
 			parts = append(parts, pathPart{
 				path:  path,

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -3150,6 +3150,29 @@ func TestDecodePanicIsCaughtAndReturnedAsError(t *testing.T) {
 	}
 }
 
+func TestDecodeIndexExceedsParserLimit(t *testing.T) {
+	type R struct {
+		N1 []*struct {
+			Value string
+		}
+	}
+	data := map[string][]string{
+		"n1.1001.value": {"Foo"},
+	}
+
+	s := new(R)
+	decoder := NewDecoder()
+	err := decoder.Decode(s, data)
+	if err == nil {
+		t.Fatal("Expected an error when index exceeds parser limit")
+	}
+
+	expected := MultiError{"n1.1001.value": UnknownKeyError{Key: "n1.1001.value"}}
+	if !reflect.DeepEqual(err, expected) {
+		t.Fatalf("Expected %v, got: %v", expected, err)
+	}
+}
+
 func BenchmarkHandleMultipartField(b *testing.B) {
 	// Create dummy file headers for testing
 	dummyFile := &multipart.FileHeader{


### PR DESCRIPTION
## Summary
- enforce a maximum index of 1000 when parsing paths
- keep negative index behavior the same and restore panic-based test
- add a new test to ensure overly large indices are rejected

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68411c0ee40c8333bc1e1339e3d43c47