### PR TITLE
Return errIndexTooLarge when parsing paths

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -123,8 +123,12 @@ func (d *Decoder) Decode(dst interface{}, src map[string][]string, files ...map[
 					multiErrors[path] = err
 				}
 			}
-		} else if !d.ignoreUnknownKeys {
-			multiErrors[path] = UnknownKeyError{Key: path}
+		} else {
+			if errors.Is(err, errIndexTooLarge) {
+				multiErrors[path] = err
+			} else if !d.ignoreUnknownKeys {
+				multiErrors[path] = UnknownKeyError{Key: path}
+			}
 		}
 	}
 	multiErrors.merge(d.setDefaults(t, v, src, ""))

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -3167,7 +3167,7 @@ func TestDecodeIndexExceedsParserLimit(t *testing.T) {
 		t.Fatal("Expected an error when index exceeds parser limit")
 	}
 
-	expected := MultiError{"n1.1001.value": UnknownKeyError{Key: "n1.1001.value"}}
+	expected := MultiError{"n1.1001.value": errIndexTooLarge}
 	if !reflect.DeepEqual(err, expected) {
 		t.Fatalf("Expected %v, got: %v", expected, err)
 	}


### PR DESCRIPTION
## Summary
- handle `errIndexTooLarge` as a decode error rather than an unknown key
- update test for the new behavior when an index exceeds the parser limit

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6851550917248333b8ccdc8b2daed1ae