### PR TITLE
🧹 chore: Improve tests coverage for decoder.go

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -3544,8 +3544,6 @@ func TestDecodeErrors(t *testing.T) {
 	})
 }
 
-// -----------------------------------------------------------------------------
-
 func TestDecodeMultipartFiles(t *testing.T) {
 	type payload struct {
 		Single   *multipart.FileHeader    `schema:"single"`
@@ -3578,8 +3576,6 @@ func TestDecodeMultipartFiles(t *testing.T) {
 	}
 }
 
-// -----------------------------------------------------------------------------
-
 func TestDecodeSliceTextUnmarshalerError(t *testing.T) {
 	type target struct {
 		B []rudeBool `schema:"b"`
@@ -3590,8 +3586,6 @@ func TestDecodeSliceTextUnmarshalerError(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 }
-
-// -----------------------------------------------------------------------------
 
 func TestDecodeCommaSeparatedZeroEmpty(t *testing.T) {
 	type target struct {
@@ -3608,8 +3602,6 @@ func TestDecodeCommaSeparatedZeroEmpty(t *testing.T) {
 	}
 }
 
-// -----------------------------------------------------------------------------
-
 func TestDecodeCommaSeparatedPointerSlice(t *testing.T) {
 	type target struct {
 		N []*int `schema:"n"`
@@ -3622,8 +3614,6 @@ func TestDecodeCommaSeparatedPointerSlice(t *testing.T) {
 		t.Fatalf("unexpected values: %v %v", s.N[0], s.N[1])
 	}
 }
-
-// -----------------------------------------------------------------------------
 
 func TestDecodeCommaSeparatedAliasSliceError(t *testing.T) {
 	type target struct {


### PR DESCRIPTION
## Summary
- expand decoder slice tests for alias, pointer, and zero-empty cases
- add multipart file decoding tests
- cover TextUnmarshaler errors for slices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new tests to improve coverage of multipart file decoding, error handling for custom slice types, and decoding of comma-separated values with various options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->