### PR TITLE
chore: Bump min go version and use typeassert

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           # NOTE: Keep this in sync with the version from go.mod
-          go-version: "1.24.x"
+          go-version: "1.25.x"
 
       - name: Run Benchmark
         run: set -o pipefail; go test ./... -benchmem -run=^$ -bench . | tee output.txt

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           # NOTE: Keep this in sync with the version from go.mod
-          go-version: "1.24.x"
+          go-version: "1.25.x"
           cache: false
 
       - name: golangci-lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   unit:
     strategy:
       matrix:
-        go-version: [1.24.x]
+        go-version: [1.25.x]
         platform: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -31,7 +31,7 @@ jobs:
         run: go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=1 -coverprofile=coverage.txt -covermode=atomic -shuffle=on
 
       - name: Upload coverage reports to Codecov
-        if: ${{ matrix.platform == 'ubuntu-latest' && matrix.go-version == '1.24.x' }}
+        if: ${{ matrix.platform == 'ubuntu-latest' && matrix.go-version == '1.25.x' }}
         uses: codecov/codecov-action@v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/encoder.go
+++ b/encoder.go
@@ -61,8 +61,8 @@ func isZero(v reflect.Value) bool {
 			IsZero() bool
 		}
 		if v.Type().Implements(reflect.TypeOf((*zero)(nil)).Elem()) {
-			iz := v.MethodByName("IsZero").Call([]reflect.Value{})[0]
-			return iz.Interface().(bool)
+			iz, _ := reflect.TypeAssert[bool](v.MethodByName("IsZero").Call([]reflect.Value{})[0])
+			return iz
 		}
 		z := true
 		for i := 0; i < v.NumField(); i++ {

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -471,7 +471,8 @@ func TestRegisterEncoderStructIsZero(t *testing.T) {
 
 		encoder := NewEncoder()
 		encoder.RegisterEncoder(time.Time{}, func(value reflect.Value) string {
-			return value.Interface().(time.Time).Format(time.RFC3339Nano)
+			tv, _ := reflect.TypeAssert[time.Time](value)
+			return tv.Format(time.RFC3339Nano)
 		})
 
 		err := encoder.Encode(ss[s], vals)
@@ -521,7 +522,7 @@ func TestRegisterEncoderWithPtrType(t *testing.T) {
 			return ""
 		}
 
-		custom := value.Interface().(*CustomTime)
+		custom, _ := reflect.TypeAssert[*CustomTime](value)
 		return custom.time.String()
 	})
 
@@ -546,7 +547,7 @@ func TestTimeDurationEncoding(t *testing.T) {
 
 	enc := NewEncoder()
 	enc.RegisterEncoder(time.Duration(0), func(v reflect.Value) string {
-		d := v.Interface().(time.Duration)
+		d, _ := reflect.TypeAssert[time.Duration](v)
 		return d.String() // "3m0s"
 	})
 
@@ -577,7 +578,8 @@ func TestTimeDurationOmitEmpty(t *testing.T) {
 
 	enc := NewEncoder()
 	enc.RegisterEncoder(time.Duration(0), func(v reflect.Value) string {
-		return v.Interface().(time.Duration).String()
+		d, _ := reflect.TypeAssert[time.Duration](v)
+		return d.String()
 	})
 
 	err := enc.Encode(&testData, vals)
@@ -731,7 +733,7 @@ func BenchmarkLargeStructEncode(b *testing.B) {
 
 	// Optionally register a custom encoder for time.Time
 	enc.RegisterEncoder(time.Time{}, func(v reflect.Value) string {
-		tVal := v.Interface().(time.Time)
+		tVal, _ := reflect.TypeAssert[time.Time](v)
 		return tVal.Format(time.RFC3339)
 	})
 
@@ -757,7 +759,7 @@ func BenchmarkLargeStructEncodeParallel(b *testing.B) {
 	}
 	enc := NewEncoder()
 	enc.RegisterEncoder(time.Time{}, func(v reflect.Value) string {
-		tVal := v.Interface().(time.Time)
+		tVal, _ := reflect.TypeAssert[time.Time](v)
 		return tVal.Format(time.RFC3339)
 	})
 
@@ -781,7 +783,8 @@ func BenchmarkTimeDurationEncoding(b *testing.B) {
 
 	enc := NewEncoder()
 	enc.RegisterEncoder(time.Duration(0), func(v reflect.Value) string {
-		return v.Interface().(time.Duration).String()
+		d, _ := reflect.TypeAssert[time.Duration](v)
+		return d.String()
 	})
 
 	vals := map[string][]string{}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/gofiber/schema
 
-go 1.24
+go 1.25


### PR DESCRIPTION
## Summary
- raise module and CI to Go 1.25
- replace direct type assertions with `reflect.TypeAssert`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a6f89e1c2c8326b880eb6f82f058b8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized type handling using a generic helper across decoding and encoding paths for improved consistency and maintainability.
  - Preserves existing behavior and public APIs; no user-facing changes expected.

- Tests
  - Updated tests and benchmarks to align with the new generic type handling approach.
  - Ensures coverage remains equivalent with no changes to expected outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->