### PR TITLE
fix(cache): clone path key before storing in pathCache

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -157,6 +157,8 @@ func (c *cache) parsePath(p string, t reflect.Type) ([]pathPart, error) {
 		c.l.Unlock()
 		return cached, nil
 	}
+	// Detach the key: callers may pass strings aliasing reused request buffers.
+	cacheKey.path = strings.Clone(p)
 	c.pathCache[cacheKey] = parts
 	c.l.Unlock()
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,33 @@
+package schema
+
+import (
+	"testing"
+
+	utils "github.com/gofiber/utils/v2"
+)
+
+// Decode callers (e.g. Fiber binders) pass map keys aliasing reused request
+// buffers; pathCache must clone the key so later buffer reuse cannot poison it.
+func TestParsePathDetachesCacheKey(t *testing.T) {
+	type S struct {
+		Entity string `schema:"entity"`
+	}
+	d := NewDecoder()
+	buf := []byte("entity")
+	var s S
+	if err := d.Decode(&s, map[string][]string{utils.UnsafeString(buf): {"x"}}); err != nil {
+		t.Fatal(err)
+	}
+	copy(buf, "policy") // simulate fasthttp buffer reuse mutating the key bytes
+
+	d.cache.l.RLock()
+	defer d.cache.l.RUnlock()
+	if len(d.cache.pathCache) != 1 {
+		t.Fatalf("expected 1 cached path, got %d", len(d.cache.pathCache))
+	}
+	for k := range d.cache.pathCache {
+		if k.path != "entity" {
+			t.Fatalf("pathCache key mutated to %q; key must be cloned before caching", k.path)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the root cause of gofiber/fiber#4534: `Bind().Query()` (and the other binders) intermittently binding empty or cross-contaminated struct fields since fiber v3.4.0.

Fiber's binders pass zero-copy keys (`utils.UnsafeString`) into `Decode`; these strings alias fasthttp's per-connection request buffers. `cache.parsePath` stored that key in the persistent `pathCache` map. Up to fiber v3.3.0 a per-request `SetAliasTag` call reset this cache on every request, which accidentally made the unsafe keys safe; gofiber/fiber#4447 removed that call, so cached keys now outlive the request. When the connection buffer is reused with a different query layout the cached key bytes mutate; map growth rehashes the mutated bytes, after which a lookup for one key can return the path parts of a different struct field. The decoder then silently binds the wrong field or none.

The fix detaches the key with `strings.Clone` before insertion. This costs one allocation per cache miss only (first time per key and type), so the hot path stays allocation-free and the perf win of gofiber/fiber#4447 is preserved.

## Verification

- New regression test `TestParsePathDetachesCacheKey` fails before the fix and passes after it; all 136 existing tests pass.
- The reproduction program from gofiber/fiber#4534 (8 keep-alive connections, 6 rotating query layouts, 240k requests): fiber main with schema at this branch shows 0 bind mismatches, versus ~65k mismatches (~43%) without the fix.

Note: merging this does not yet fix the fiber issue for users; fiber needs a schema release plus a go.mod bump afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path caching to remain reliable when input buffers are reused or modified.
  * Prevented cached schema paths from changing unexpectedly after decoding.

* **Tests**
  * Added coverage confirming cached paths retain their original values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->