### PR TITLE
⚡ perf: SWAR-accelerated path lookup, fast scalar/slice decode, fewer encoder allocations

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -23,6 +23,11 @@ const maxParserIndex = 1000
 // against the direct-path map; longer keys take the generic path.
 const maxDirectKeyLen = 64
 
+// maxDirectPaths caps the nested entries precomputed per struct type: deep
+// fan-out nesting multiplies dotted chains, and without a cap build time and
+// retained memory grow exponentially. Excess keys use the generic parser.
+const maxDirectPaths = 512
+
 var (
 	errInvalidPath   = errors.New("schema: invalid path")
 	errIndexTooLarge = errors.New("schema: index exceeds parser limit")
@@ -348,31 +353,38 @@ func (c *cache) create(t reflect.Type, parentAlias string) *structInfo {
 // through non-pointer nested struct fields.
 func (c *cache) buildDirectPaths(info *structInfo) map[string][]pathPart {
 	direct := make(map[string][]pathPart, len(info.fieldsByName))
-	for aliasKey, f := range info.fieldsByName {
-		if strings.IndexByte(aliasKey, '.') >= 0 {
+	// Flat aliases first (linear in field count) so the cap below can never
+	// crowd them out; iterate fields in declaration order, honoring
+	// fieldsByName's first-wins rule.
+	for _, f := range info.fields {
+		if !directEligible(info, f) {
 			continue
 		}
-		if f.isSliceOfStructs && !f.isMultipart && (!f.unmarshalerInfo.IsValid || f.unmarshalerInfo.IsSliceElement) {
-			// The path must continue with a slice index; a bare alias is invalid.
-			continue
-		}
-		hop := pathHop{index: f.index, ensure: info.anonymousPtrFields}
-		direct[aliasKey] = []pathPart{{
-			hops:  []pathHop{hop},
+		direct[f.aliasLower] = []pathPart{{
+			hops:  []pathHop{{index: f.index, ensure: info.anonymousPtrFields}},
 			field: f,
 			index: -1,
 		}}
-		if f.typ.Kind() != reflect.Struct {
+	}
+	for _, f := range info.fields {
+		if len(direct) >= maxDirectPaths {
+			break
+		}
+		if !directEligible(info, f) || f.typ.Kind() != reflect.Struct {
 			continue
 		}
 		// Non-pointer struct nesting cannot recurse (the type would be
 		// illegal), so the child's info is always buildable here.
+		hop := pathHop{index: f.index, ensure: info.anonymousPtrFields}
 		for childKey, childParts := range c.get(f.typ).direct {
+			if len(direct) >= maxDirectPaths {
+				break
+			}
 			cp := childParts[0]
 			hops := make([]pathHop, 0, len(cp.hops)+1)
 			hops = append(hops, hop)
 			hops = append(hops, cp.hops...)
-			direct[aliasKey+"."+childKey] = []pathPart{{
+			direct[f.aliasLower+"."+childKey] = []pathPart{{
 				hops:  hops,
 				field: cp.field,
 				index: -1,
@@ -380,6 +392,17 @@ func (c *cache) buildDirectPaths(info *structInfo) map[string][]pathPart {
 		}
 	}
 	return direct
+}
+
+// directEligible reports whether f can serve as a direct-path terminal: it is
+// its alias's first-wins winner, the alias has no dot, and a bare alias is a
+// valid path (slice-of-structs fields require a following slice index).
+func directEligible(info *structInfo, f *fieldInfo) bool {
+	if info.fieldsByName[f.aliasLower] != f || strings.IndexByte(f.aliasLower, '.') >= 0 {
+		return false
+	}
+	needsIndex := f.isSliceOfStructs && !f.isMultipart && (!f.unmarshalerInfo.IsValid || f.unmarshalerInfo.IsSliceElement)
+	return !needsIndex
 }
 
 // needsDefaultsWalk reports whether the setDefaults walk can have any effect

--- a/cache.go
+++ b/cache.go
@@ -19,6 +19,11 @@ import (
 
 const maxParserIndex = 1000
 
+// maxDirectKeyLen bounds the stack buffer used to case-fold keys probed
+// against the precomputed direct-path map; longer keys take the generic
+// parse-and-cache path.
+const maxDirectKeyLen = 64
+
 var (
 	errInvalidPath   = errors.New("schema: invalid path")
 	errIndexTooLarge = errors.New("schema: index exceeds parser limit")
@@ -88,6 +93,40 @@ func (c *cache) parsePath(p string, t reflect.Type) ([]pathPart, error) {
 // parsed-path cache lives on that structInfo, keyed by the plain path
 // string, which hashes much cheaper than a composite key.
 func (c *cache) parsePathInfo(p string, rootInfo *structInfo) ([]pathPart, error) {
+	// Fast path: keys that resolve without runtime state (flat aliases and
+	// dotted chains through non-pointer nested structs) were precomputed into
+	// rootInfo.direct at build time. Lower the key word-at-a-time (SWAR) into
+	// a stack buffer so the lookup is case-insensitive without allocating,
+	// and probe the plain immutable map instead of the sync.Map path cache.
+	// Mixed-case keys hitting here also never pollute the path cache with
+	// per-casing clones.
+	if n := len(p); n <= maxDirectKeyLen && len(rootInfo.direct) > 0 {
+		var buf [maxDirectKeyLen]byte
+		changed := false
+		i := 0
+		for ; i+swar.WordLen <= n; i += swar.WordLen {
+			w := swar.Load8(p, i)
+			lw := swar.ToLowerWord(w)
+			changed = changed || lw != w
+			swar.Store8(buf[:], i, lw)
+		}
+		for ; i < n; i++ {
+			ch := p[i]
+			if ch >= 'A' && ch <= 'Z' {
+				ch += 'a' - 'A'
+				changed = true
+			}
+			buf[i] = ch
+		}
+		if changed {
+			if parts, ok := rootInfo.direct[string(buf[:n])]; ok {
+				return parts, nil
+			}
+		} else if parts, ok := rootInfo.direct[p]; ok {
+			return parts, nil
+		}
+	}
+
 	if cached, ok := rootInfo.paths.Load(p); ok {
 		return cached.([]pathPart), nil
 	}
@@ -298,11 +337,58 @@ func (c *cache) create(t reflect.Type, parentAlias string) *structInfo {
 		}
 	}
 	info.requiredFields = c.buildRequiredFields(info)
+	info.direct = c.buildDirectPaths(info)
 	// The setDefaults walk also allocates nil anonymous embedded pointers,
 	// so it can only be skipped when neither defaults nor such pointers
 	// exist anywhere in the tree.
 	info.needsDefaultsWalk = c.needsDefaultsWalk(t, tag, map[reflect.Type]bool{})
 	return info
+}
+
+// buildDirectPaths precomputes the parsed paths parsePathInfo would produce
+// for every key that resolves without runtime state: each field alias, plus
+// dotted chains through nested non-pointer struct fields (their child maps
+// compose recursively). Slice-of-structs fields that require a slice index in
+// the path and aliases containing '.' are left to the generic parser, as are
+// chains through pointer fields (whose element type could reach back to a
+// struct currently being built). Keys are lowercase, mirroring the
+// case-insensitive per-segment lookups of the generic parser.
+func (c *cache) buildDirectPaths(info *structInfo) map[string][]pathPart {
+	direct := make(map[string][]pathPart, len(info.fieldsByName))
+	for aliasKey, f := range info.fieldsByName {
+		if strings.IndexByte(aliasKey, '.') >= 0 {
+			continue
+		}
+		if f.isSliceOfStructs && !f.isMultipart && (!f.unmarshalerInfo.IsValid || f.unmarshalerInfo.IsSliceElement) {
+			// The path must continue with a slice index; a bare alias is
+			// invalid, so the generic parser handles this field.
+			continue
+		}
+		hop := pathHop{index: f.index, ensure: info.anonymousPtrFields}
+		direct[aliasKey] = []pathPart{{
+			hops:  []pathHop{hop},
+			field: f,
+			index: -1,
+		}}
+		if f.typ.Kind() != reflect.Struct {
+			continue
+		}
+		// Non-pointer struct nesting cannot recurse (the type would be
+		// illegal), so the child's info — including its own direct map — is
+		// always buildable here.
+		for childKey, childParts := range c.get(f.typ).direct {
+			cp := childParts[0]
+			hops := make([]pathHop, 0, len(cp.hops)+1)
+			hops = append(hops, hop)
+			hops = append(hops, cp.hops...)
+			direct[aliasKey+"."+childKey] = []pathPart{{
+				hops:  hops,
+				field: cp.field,
+				index: -1,
+			}}
+		}
+	}
+	return direct
 }
 
 // needsDefaultsWalk reports whether the setDefaults walk can have any effect
@@ -423,6 +509,12 @@ type structInfo struct {
 	fieldsByName       map[string]*fieldInfo
 	anonymousPtrFields []int
 	requiredFields     map[string][]fieldWithPrefix
+	// direct maps lowercase keys that resolve without runtime state — flat
+	// field aliases and dotted chains through non-pointer nested structs —
+	// to their precomputed parsed paths. It is built once with the
+	// structInfo and immutable afterwards, so parsePathInfo can serve the
+	// common case with a plain map probe instead of the sync.Map below.
+	direct map[string][]pathPart
 	// paths caches parsed paths rooted at this struct type
 	// (map[string][]pathPart); keys are cloned so they never alias reused
 	// request buffers.

--- a/cache.go
+++ b/cache.go
@@ -20,8 +20,7 @@ import (
 const maxParserIndex = 1000
 
 // maxDirectKeyLen bounds the stack buffer used to case-fold keys probed
-// against the precomputed direct-path map; longer keys take the generic
-// parse-and-cache path.
+// against the direct-path map; longer keys take the generic path.
 const maxDirectKeyLen = 64
 
 var (
@@ -93,37 +92,36 @@ func (c *cache) parsePath(p string, t reflect.Type) ([]pathPart, error) {
 // parsed-path cache lives on that structInfo, keyed by the plain path
 // string, which hashes much cheaper than a composite key.
 func (c *cache) parsePathInfo(p string, rootInfo *structInfo) ([]pathPart, error) {
-	// Fast path: keys that resolve without runtime state (flat aliases and
-	// dotted chains through non-pointer nested structs) were precomputed into
-	// rootInfo.direct at build time. Lower the key word-at-a-time (SWAR) into
-	// a stack buffer so the lookup is case-insensitive without allocating,
-	// and probe the plain immutable map instead of the sync.Map path cache.
-	// Mixed-case keys hitting here also never pollute the path cache with
-	// per-casing clones.
-	if n := len(p); n <= maxDirectKeyLen && len(rootInfo.direct) > 0 {
-		var buf [maxDirectKeyLen]byte
-		changed := false
-		i := 0
-		for ; i+swar.WordLen <= n; i += swar.WordLen {
-			w := swar.Load8(p, i)
-			lw := swar.ToLowerWord(w)
-			changed = changed || lw != w
-			swar.Store8(buf[:], i, lw)
-		}
-		for ; i < n; i++ {
-			ch := p[i]
-			if ch >= 'A' && ch <= 'Z' {
-				ch += 'a' - 'A'
-				changed = true
-			}
-			buf[i] = ch
-		}
-		if changed {
-			if parts, ok := rootInfo.direct[string(buf[:n])]; ok {
-				return parts, nil
-			}
-		} else if parts, ok := rootInfo.direct[p]; ok {
+	// Fast path: probe the precomputed direct-path map with the raw key
+	// (keys are usually already lowercase); on a miss, case-fold the key
+	// word-at-a-time (SWAR) into a stack buffer and probe once more.
+	if len(rootInfo.direct) > 0 {
+		if parts, ok := rootInfo.direct[p]; ok {
 			return parts, nil
+		}
+		if n := len(p); n <= maxDirectKeyLen {
+			var buf [maxDirectKeyLen]byte
+			changed := false
+			i := 0
+			for ; i+swar.WordLen <= n; i += swar.WordLen {
+				w := swar.Load8(p, i)
+				lw := swar.ToLowerWord(w)
+				changed = changed || lw != w
+				swar.Store8(buf[:], i, lw)
+			}
+			for ; i < n; i++ {
+				ch := p[i]
+				if ch >= 'A' && ch <= 'Z' {
+					ch += 'a' - 'A'
+					changed = true
+				}
+				buf[i] = ch
+			}
+			if changed {
+				if parts, ok := rootInfo.direct[string(buf[:n])]; ok {
+					return parts, nil
+				}
+			}
 		}
 	}
 
@@ -345,14 +343,9 @@ func (c *cache) create(t reflect.Type, parentAlias string) *structInfo {
 	return info
 }
 
-// buildDirectPaths precomputes the parsed paths parsePathInfo would produce
-// for every key that resolves without runtime state: each field alias, plus
-// dotted chains through nested non-pointer struct fields (their child maps
-// compose recursively). Slice-of-structs fields that require a slice index in
-// the path and aliases containing '.' are left to the generic parser, as are
-// chains through pointer fields (whose element type could reach back to a
-// struct currently being built). Keys are lowercase, mirroring the
-// case-insensitive per-segment lookups of the generic parser.
+// buildDirectPaths precomputes, keyed by lowercase path, the parsed paths for
+// every key resolvable without runtime state: flat aliases plus dotted chains
+// through non-pointer nested struct fields.
 func (c *cache) buildDirectPaths(info *structInfo) map[string][]pathPart {
 	direct := make(map[string][]pathPart, len(info.fieldsByName))
 	for aliasKey, f := range info.fieldsByName {
@@ -360,8 +353,7 @@ func (c *cache) buildDirectPaths(info *structInfo) map[string][]pathPart {
 			continue
 		}
 		if f.isSliceOfStructs && !f.isMultipart && (!f.unmarshalerInfo.IsValid || f.unmarshalerInfo.IsSliceElement) {
-			// The path must continue with a slice index; a bare alias is
-			// invalid, so the generic parser handles this field.
+			// The path must continue with a slice index; a bare alias is invalid.
 			continue
 		}
 		hop := pathHop{index: f.index, ensure: info.anonymousPtrFields}
@@ -374,8 +366,7 @@ func (c *cache) buildDirectPaths(info *structInfo) map[string][]pathPart {
 			continue
 		}
 		// Non-pointer struct nesting cannot recurse (the type would be
-		// illegal), so the child's info — including its own direct map — is
-		// always buildable here.
+		// illegal), so the child's info is always buildable here.
 		for childKey, childParts := range c.get(f.typ).direct {
 			cp := childParts[0]
 			hops := make([]pathHop, 0, len(cp.hops)+1)
@@ -476,8 +467,18 @@ func (c *cache) createField(field reflect.StructField, parentAlias, tag string) 
 		elemU = isTextUnmarshaler(reflect.Zero(ft))
 	}
 
+	// Non-pointer builtin scalars without unmarshalers or custom converters
+	// can skip decode's dispatch entirely; converter registration resets the
+	// cache, so this build-time decision stays valid.
+	fastKind := reflect.Invalid
+	if k := field.Type.Kind(); k != reflect.Ptr && !m.IsValid &&
+		getBuiltinConverter(k) != nil && c.converter(field.Type) == nil {
+		fastKind = k
+	}
+
 	return &fieldInfo{
 		typ:              field.Type,
+		fastKind:         fastKind,
 		name:             field.Name,
 		alias:            alias,
 		aliasLower:       utilstrings.ToLower(alias),
@@ -509,11 +510,8 @@ type structInfo struct {
 	fieldsByName       map[string]*fieldInfo
 	anonymousPtrFields []int
 	requiredFields     map[string][]fieldWithPrefix
-	// direct maps lowercase keys that resolve without runtime state — flat
-	// field aliases and dotted chains through non-pointer nested structs —
-	// to their precomputed parsed paths. It is built once with the
-	// structInfo and immutable afterwards, so parsePathInfo can serve the
-	// common case with a plain map probe instead of the sync.Map below.
+	// direct maps lowercase statically-resolvable keys to their precomputed
+	// parsed paths; built once and immutable, see buildDirectPaths.
 	direct map[string][]pathPart
 	// paths caches parsed paths rooted at this struct type
 	// (map[string][]pathPart); keys are cloned so they never alias reused
@@ -570,6 +568,9 @@ func containsAlias(infos []*structInfo, alias string) bool {
 
 type fieldInfo struct {
 	typ reflect.Type
+	// fastKind is the field's builtin scalar kind when decode can set it
+	// directly (no pointer, unmarshaler, or custom converter); else Invalid.
+	fastKind reflect.Kind
 	// index is the field index chain relative to the struct type whose
 	// structInfo holds this fieldInfo; promoted fields carry the full chain
 	// through the embedded structs (a copy is made per promotion level).

--- a/cache_test.go
+++ b/cache_test.go
@@ -119,9 +119,8 @@ func BenchmarkParsePathCacheMiss(b *testing.B) {
 // Decode callers (e.g. Fiber binders) pass map keys aliasing reused request
 // buffers; pathCache must clone the key so later buffer reuse cannot poison it.
 func TestParsePathDetachesCacheKey(t *testing.T) {
-	// Use a slice-index path: statically resolvable keys are served from the
-	// precomputed direct map and never stored in the sync.Map path cache, so
-	// only index-carrying paths exercise the clone-on-store behavior.
+	// Use a slice-index path: statically-resolvable keys are served from the
+	// direct map and never stored in the sync.Map path cache.
 	type Item struct {
 		Value string `schema:"value"`
 	}

--- a/cache_test.go
+++ b/cache_test.go
@@ -119,21 +119,27 @@ func BenchmarkParsePathCacheMiss(b *testing.B) {
 // Decode callers (e.g. Fiber binders) pass map keys aliasing reused request
 // buffers; pathCache must clone the key so later buffer reuse cannot poison it.
 func TestParsePathDetachesCacheKey(t *testing.T) {
+	// Use a slice-index path: statically resolvable keys are served from the
+	// precomputed direct map and never stored in the sync.Map path cache, so
+	// only index-carrying paths exercise the clone-on-store behavior.
+	type Item struct {
+		Value string `schema:"value"`
+	}
 	type S struct {
-		Entity string `schema:"entity"`
+		Items []Item `schema:"items"`
 	}
 	d := NewDecoder()
-	buf := []byte("entity")
+	buf := []byte("items.0.value")
 	var s S
 	if err := d.Decode(&s, map[string][]string{utils.UnsafeString(buf): {"x"}}); err != nil {
 		t.Fatal(err)
 	}
-	copy(buf, "policy") // simulate fasthttp buffer reuse mutating the key bytes
+	copy(buf, "xtems.9.qalue") // simulate fasthttp buffer reuse mutating the key bytes
 
 	count := 0
 	d.cache.get(reflect.TypeOf(s)).paths.Range(func(key, _ any) bool {
 		count++
-		if k := key.(string); k != "entity" {
+		if k := key.(string); k != "items.0.value" {
 			t.Fatalf("path cache key mutated to %q; key must be cloned before caching", k)
 		}
 		return true

--- a/converter.go
+++ b/converter.go
@@ -169,6 +169,45 @@ func convertUint64(value string) reflect.Value {
 	return invalidValue
 }
 
+// parseNative* adapt the builtin parsers to the (T, bool) shape used by the
+// native slice decode path. They mirror setBuiltinKind's per-kind behavior,
+// including the native-fit guards for int/uint.
+
+func parseNativeString(s string) (string, bool) { return s, true }
+
+func parseNativeInt(s string) (int, bool) {
+	n, err := utils.ParseInt(s)
+	return int(n), err == nil && int64(int(n)) == n
+}
+
+func parseNativeInt64(s string) (int64, bool) {
+	n, err := utils.ParseInt(s)
+	return n, err == nil
+}
+
+func parseNativeUint(s string) (uint, bool) {
+	n, err := utils.ParseUint(s)
+	return uint(n), err == nil && uint64(uint(n)) == n
+}
+
+func parseNativeUint64(s string) (uint64, bool) {
+	n, err := utils.ParseUint(s)
+	return n, err == nil
+}
+
+func parseNativeFloat64(s string) (float64, bool) {
+	f, err := utils.ParseFloat64(s)
+	return f, err == nil
+}
+
+func parseNativeBool(s string) (bool, bool) {
+	if s == "on" {
+		return true, true
+	}
+	b, err := strconv.ParseBool(s)
+	return b, err == nil
+}
+
 // setBuiltinKind parses val and assigns it directly into v for builtin
 // convertible kinds, avoiding the reflect.Value boxing of the Converter API.
 // handled reports whether the kind is builtin-convertible; ok reports whether

--- a/converter.go
+++ b/converter.go
@@ -170,8 +170,7 @@ func convertUint64(value string) reflect.Value {
 }
 
 // parseNative* adapt the builtin parsers to the (T, bool) shape used by the
-// native slice decode path. They mirror setBuiltinKind's per-kind behavior,
-// including the native-fit guards for int/uint.
+// native slice decode path, mirroring setBuiltinKind's per-kind behavior.
 
 func parseNativeString(s string) (string, bool) { return s, true }
 

--- a/decoder.go
+++ b/decoder.go
@@ -871,13 +871,10 @@ func decodeNativeSlice[T any](zeroEmpty bool, v reflect.Value, path string, valu
 			out = append(out, ev)
 		}
 	}
-	// v's type is exactly []T here; assigning through the typed pointer skips
-	// reflect.ValueOf's slice-header escape and Set's assignability checks.
-	if p, ok := v.Addr().Interface().(*[]T); ok {
-		*p = out
-	} else {
-		v.Set(reflect.ValueOf(out))
-	}
+	// v's type is exactly []T here (the dispatch switch guarantees it), so
+	// assign through the typed pointer: no reflect.ValueOf escape, no Set
+	// assignability checks, and a loud panic if the invariant is ever broken.
+	*v.Addr().Interface().(*[]T) = out
 	return nil
 }
 

--- a/decoder.go
+++ b/decoder.go
@@ -488,6 +488,29 @@ func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart, values 
 		return nil
 	}
 
+	// Fast path: plain builtin scalar fields skip the converter/unmarshaler
+	// dispatch below; fastKind was validated at cache-build time.
+	if k := parts[0].field.fastKind; k != reflect.Invalid && len(parts) == 1 && !parts[0].elem {
+		val := ""
+		if len(values) > 0 {
+			val = values[len(values)-1]
+		}
+		if val == "" {
+			if d.zeroEmpty {
+				v.SetZero()
+			}
+			return nil
+		}
+		if _, ok := setBuiltinKind(v, k, val); !ok {
+			return ConversionError{
+				Key:   path,
+				Type:  parts[0].field.typ,
+				Index: -1,
+			}
+		}
+		return nil
+	}
+
 	// Check multipart files
 	if parts[0].field.isMultipart && handleMultipartField(v, files) {
 		return nil
@@ -733,9 +756,8 @@ func (d *Decoder) decodeBuiltinSlice(v reflect.Value, t reflect.Type, path strin
 		n++
 	}
 
-	// Exact builtin slice types fill a native Go slice and assign it in one
-	// Set, skipping reflect.MakeSlice and the per-element Index/Set calls.
-	// Named slice or element types fall through to the generic path.
+	// Exact builtin slice types decode without per-element reflect calls;
+	// named slice or element types fall through to the generic path.
 	switch t {
 	case typSliceString:
 		return decodeNativeSlice(d.zeroEmpty, v, path, values, elemT, n, split, parseNativeString)
@@ -807,11 +829,9 @@ var (
 	typSliceBool    = reflect.TypeOf([]bool(nil))
 )
 
-// decodeNativeSlice mirrors the generic decodeBuiltinSlice loop for a slice
-// field whose type is exactly []T: elements are parsed into a native Go slice
-// and assigned with a single Set, so no reflect calls happen per element. The
-// slice is built detached and only assigned when every value parsed, keeping
-// the all-or-nothing behavior. n is the precomputed element upper bound.
+// decodeNativeSlice mirrors the generic decodeBuiltinSlice loop for a field
+// typed exactly []T, parsing into a native slice assigned only if every value
+// parsed (all-or-nothing). n is the precomputed element upper bound.
 func decodeNativeSlice[T any](zeroEmpty bool, v reflect.Value, path string, values []string, elemT reflect.Type, n int, split bool, parse func(string) (T, bool)) error {
 	out := make([]T, 0, n)
 	var zero T
@@ -851,9 +871,8 @@ func decodeNativeSlice[T any](zeroEmpty bool, v reflect.Value, path string, valu
 			out = append(out, ev)
 		}
 	}
-	// v's type is exactly []T here, so assign through the typed pointer;
-	// this skips reflect.ValueOf's escape of the slice header and Set's
-	// assignability checks.
+	// v's type is exactly []T here; assigning through the typed pointer skips
+	// reflect.ValueOf's slice-header escape and Set's assignability checks.
 	if p, ok := v.Addr().Interface().(*[]T); ok {
 		*p = out
 	} else {

--- a/decoder.go
+++ b/decoder.go
@@ -733,6 +733,26 @@ func (d *Decoder) decodeBuiltinSlice(v reflect.Value, t reflect.Type, path strin
 		n++
 	}
 
+	// Exact builtin slice types fill a native Go slice and assign it in one
+	// Set, skipping reflect.MakeSlice and the per-element Index/Set calls.
+	// Named slice or element types fall through to the generic path.
+	switch t {
+	case typSliceString:
+		return decodeNativeSlice(d.zeroEmpty, v, path, values, elemT, n, split, parseNativeString)
+	case typSliceInt:
+		return decodeNativeSlice(d.zeroEmpty, v, path, values, elemT, n, split, parseNativeInt)
+	case typSliceInt64:
+		return decodeNativeSlice(d.zeroEmpty, v, path, values, elemT, n, split, parseNativeInt64)
+	case typSliceUint:
+		return decodeNativeSlice(d.zeroEmpty, v, path, values, elemT, n, split, parseNativeUint)
+	case typSliceUint64:
+		return decodeNativeSlice(d.zeroEmpty, v, path, values, elemT, n, split, parseNativeUint64)
+	case typSliceFloat64:
+		return decodeNativeSlice(d.zeroEmpty, v, path, values, elemT, n, split, parseNativeFloat64)
+	case typSliceBool:
+		return decodeNativeSlice(d.zeroEmpty, v, path, values, elemT, n, split, parseNativeBool)
+	}
+
 	sl := reflect.MakeSlice(t, n, n)
 	i := 0
 	for key, value := range values {
@@ -773,6 +793,72 @@ func (d *Decoder) decodeBuiltinSlice(v reflect.Value, t reflect.Type, path strin
 		sl = sl.Slice(0, i)
 	}
 	v.Set(sl)
+	return nil
+}
+
+// Exact (unnamed) builtin slice types eligible for the native decode path.
+var (
+	typSliceString  = reflect.TypeOf([]string(nil))
+	typSliceInt     = reflect.TypeOf([]int(nil))
+	typSliceInt64   = reflect.TypeOf([]int64(nil))
+	typSliceUint    = reflect.TypeOf([]uint(nil))
+	typSliceUint64  = reflect.TypeOf([]uint64(nil))
+	typSliceFloat64 = reflect.TypeOf([]float64(nil))
+	typSliceBool    = reflect.TypeOf([]bool(nil))
+)
+
+// decodeNativeSlice mirrors the generic decodeBuiltinSlice loop for a slice
+// field whose type is exactly []T: elements are parsed into a native Go slice
+// and assigned with a single Set, so no reflect calls happen per element. The
+// slice is built detached and only assigned when every value parsed, keeping
+// the all-or-nothing behavior. n is the precomputed element upper bound.
+func decodeNativeSlice[T any](zeroEmpty bool, v reflect.Value, path string, values []string, elemT reflect.Type, n int, split bool, parse func(string) (T, bool)) error {
+	out := make([]T, 0, n)
+	var zero T
+	for key, value := range values {
+		switch {
+		case value == "":
+			if zeroEmpty {
+				out = append(out, zero)
+			}
+		case split && strings.IndexByte(value, ',') != -1:
+			for item := range strings.SplitSeq(value, ",") {
+				if item == "" {
+					if zeroEmpty {
+						out = append(out, zero)
+					}
+					continue
+				}
+				ev, ok := parse(item)
+				if !ok {
+					return ConversionError{
+						Key:   path,
+						Type:  elemT,
+						Index: key,
+					}
+				}
+				out = append(out, ev)
+			}
+		default:
+			ev, ok := parse(value)
+			if !ok {
+				return ConversionError{
+					Key:   path,
+					Type:  elemT,
+					Index: key,
+				}
+			}
+			out = append(out, ev)
+		}
+	}
+	// v's type is exactly []T here, so assign through the typed pointer;
+	// this skips reflect.ValueOf's escape of the slice header and Set's
+	// assignability checks.
+	if p, ok := v.Addr().Interface().(*[]T); ok {
+		*p = out
+	} else {
+		v.Set(reflect.ValueOf(out))
+	}
 	return nil
 }
 

--- a/encoder.go
+++ b/encoder.go
@@ -214,6 +214,27 @@ func (e *Encoder) encode(v reflect.Value, dst map[string][]string) error {
 	var errs MultiError
 
 	fields := e.structInfo(v.Type())
+	// When dst starts empty (fresh url.Values), single values of distinct keys
+	// share one backing array instead of allocating a 1-element slice each;
+	// the three-index slice caps entries so later appends cannot overwrite a
+	// neighbor. A non-empty dst keeps the single-map-op append pattern.
+	useScratch := len(dst) == 0
+	var scratch []string
+	appendValue := func(name, s string) {
+		if !useScratch {
+			dst[name] = append(dst[name], s)
+			return
+		}
+		if old := dst[name]; old != nil {
+			dst[name] = append(old, s)
+			return
+		}
+		if scratch == nil {
+			scratch = make([]string, 0, len(fields))
+		}
+		scratch = append(scratch, s)
+		dst[name] = scratch[len(scratch)-1 : len(scratch) : len(scratch)]
+	}
 	for i := range fields {
 		f := &fields[i]
 		fieldValue := v.Field(f.idx)
@@ -231,7 +252,7 @@ func (e *Encoder) encode(v reflect.Value, dst map[string][]string) error {
 			if f.omitEmpty && isZero(fieldValue) {
 				continue
 			}
-			dst[f.name] = append(dst[f.name], f.enc(fieldValue))
+			appendValue(f.name, f.enc(fieldValue))
 			continue
 		}
 
@@ -239,7 +260,7 @@ func (e *Encoder) encode(v reflect.Value, dst map[string][]string) error {
 			if f.omitEmpty {
 				continue
 			}
-			dst[f.name] = append(dst[f.name], "null")
+			appendValue(f.name, "null")
 			continue
 		}
 

--- a/encoder.go
+++ b/encoder.go
@@ -23,7 +23,9 @@ var errNilDst = errors.New("schema: dst map must not be nil")
 
 // maxScratchValueLen bounds values stored in encode's shared scratch array,
 // capping how much data a surviving dst entry can keep reachable after the
-// caller deletes neighboring keys.
+// caller deletes neighboring keys. Only strings allocated by this package's
+// own formatters are eligible at all (see encField.scratchSafe), so the cap
+// bounds real bytes, not just headers.
 const maxScratchValueLen = 64
 
 // Encoder encodes values from a struct into url.Values.
@@ -60,6 +62,10 @@ type encField struct {
 	// recurseStructPtr marks pointer-to-struct fields without a custom
 	// encoder: non-nil values are encoded by recursing into the element.
 	recurseStructPtr bool
+	// scratchSafe marks fields whose encoder output is allocated by this
+	// package (numeric/bool/float formatters), so it can never alias a large
+	// caller-owned buffer and may be batched in encode's shared scratch.
+	scratchSafe bool
 	isStruct         bool
 	// nilAsNull marks pointer fields whose element has no immediate
 	// encoder (structs recursed via recurseStructPtr, or unsupported
@@ -151,7 +157,8 @@ func (e *Encoder) structInfo(t reflect.Type) []encField {
 			recurseStructPtr: ft.Kind() == reflect.Ptr &&
 				ft.Elem().Kind() == reflect.Struct &&
 				!e.hasCustomEncoder(ft),
-			enc: typeEncoder(ft, e.regenc),
+			enc:         typeEncoder(ft, e.regenc),
+			scratchSafe: scratchSafeEncoder(ft, e.regenc),
 		}
 		if f.enc == nil {
 			switch ft.Kind() {
@@ -219,16 +226,17 @@ func (e *Encoder) encode(v reflect.Value, dst map[string][]string) error {
 	var errs MultiError
 
 	fields := e.structInfo(v.Type())
-	// When dst starts empty (fresh url.Values), single short values of
-	// distinct keys share one backing array instead of allocating a 1-element
-	// slice each; the three-index slice caps entries so later appends cannot
-	// overwrite a neighbor. Long values get their own slice so a surviving
-	// entry cannot pin a deleted neighbor's large string, and a non-empty dst
-	// keeps the single-map-op append pattern.
+	// When dst starts empty (fresh url.Values), single short package-allocated
+	// values of distinct keys share one backing array instead of allocating a
+	// 1-element slice each; the three-index slice caps entries so later
+	// appends cannot overwrite a neighbor. Caller-derived strings (string
+	// fields, custom encoders) and long values get their own independently
+	// collectible slice so a surviving entry cannot keep a deleted neighbor's
+	// allocation alive; a non-empty dst keeps the single-map-op append pattern.
 	useScratch := len(dst) == 0
 	var scratch []string
-	appendValue := func(name, s string) {
-		if !useScratch || len(s) > maxScratchValueLen {
+	appendValue := func(name, s string, scratchSafe bool) {
+		if !useScratch || !scratchSafe || len(s) > maxScratchValueLen {
 			dst[name] = append(dst[name], s)
 			return
 		}
@@ -259,7 +267,7 @@ func (e *Encoder) encode(v reflect.Value, dst map[string][]string) error {
 			if f.omitEmpty && isZero(fieldValue) {
 				continue
 			}
-			appendValue(f.name, f.enc(fieldValue))
+			appendValue(f.name, f.enc(fieldValue), f.scratchSafe)
 			continue
 		}
 
@@ -267,7 +275,8 @@ func (e *Encoder) encode(v reflect.Value, dst map[string][]string) error {
 			if f.omitEmpty {
 				continue
 			}
-			appendValue(f.name, "null")
+			// The "null" literal is static data; always scratch-safe.
+			appendValue(f.name, "null", true)
 			continue
 		}
 
@@ -338,6 +347,27 @@ func setError(m MultiError, key string, err error) MultiError {
 func (e *Encoder) hasCustomEncoder(t reflect.Type) bool {
 	_, exists := e.regenc[t]
 	return exists
+}
+
+// scratchSafeEncoder reports whether typeEncoder(t, reg)'s output strings are
+// always allocated by this package's own formatters: string fields return the
+// caller's string and custom encoders may return anything — either could be a
+// small substring aliasing a large buffer, so neither may enter the scratch.
+func scratchSafeEncoder(t reflect.Type, reg map[reflect.Type]encoderFunc) bool {
+	if _, ok := reg[t]; ok {
+		return false
+	}
+	switch t.Kind() {
+	case reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return true
+	case reflect.Ptr:
+		return scratchSafeEncoder(t.Elem(), reg)
+	default:
+		return false
+	}
 }
 
 func typeEncoder(t reflect.Type, reg map[reflect.Type]encoderFunc) encoderFunc {

--- a/encoder.go
+++ b/encoder.go
@@ -21,6 +21,11 @@ var errNotStruct = errors.New("schema: interface must be a struct")
 // would otherwise panic on the first map assignment.
 var errNilDst = errors.New("schema: dst map must not be nil")
 
+// maxScratchValueLen bounds values stored in encode's shared scratch array,
+// capping how much data a surviving dst entry can keep reachable after the
+// caller deletes neighboring keys.
+const maxScratchValueLen = 64
+
 // Encoder encodes values from a struct into url.Values.
 type Encoder struct {
 	cache  *cache
@@ -214,14 +219,16 @@ func (e *Encoder) encode(v reflect.Value, dst map[string][]string) error {
 	var errs MultiError
 
 	fields := e.structInfo(v.Type())
-	// When dst starts empty (fresh url.Values), single values of distinct keys
-	// share one backing array instead of allocating a 1-element slice each;
-	// the three-index slice caps entries so later appends cannot overwrite a
-	// neighbor. A non-empty dst keeps the single-map-op append pattern.
+	// When dst starts empty (fresh url.Values), single short values of
+	// distinct keys share one backing array instead of allocating a 1-element
+	// slice each; the three-index slice caps entries so later appends cannot
+	// overwrite a neighbor. Long values get their own slice so a surviving
+	// entry cannot pin a deleted neighbor's large string, and a non-empty dst
+	// keeps the single-map-op append pattern.
 	useScratch := len(dst) == 0
 	var scratch []string
 	appendValue := func(name, s string) {
-		if !useScratch {
+		if !useScratch || len(s) > maxScratchValueLen {
 			dst[name] = append(dst[name], s)
 			return
 		}

--- a/fastpath_test.go
+++ b/fastpath_test.go
@@ -228,25 +228,26 @@ func TestGenericScalarFallbacks(t *testing.T) {
 	}
 }
 
-// Two fields sharing an alias must both land under the key when encoding into
-// a fresh dst (the scratch path's append branch), and values longer than
-// maxScratchValueLen must bypass the shared scratch array.
+// Encoding into a fresh dst must handle every appendValue branch: duplicate
+// aliases appending to a scratch-backed entry, caller-derived strings and
+// long formatter output bypassing the shared scratch, and short numeric
+// values using it.
 func TestEncodeDuplicateAliasFreshDst(t *testing.T) {
 	type S struct {
-		A string `schema:"k"`
-		B string `schema:"k"`
-		C string `schema:"c"`
-		L string `schema:"l"`
+		A int     `schema:"k"`
+		B int     `schema:"k"`
+		C string  `schema:"c"`
+		L float64 `schema:"l"`
 	}
-	long := strings.Repeat("x", maxScratchValueLen+1)
 	dst := map[string][]string{}
-	if err := NewEncoder().Encode(S{A: "1", B: "2", C: "3", L: long}, dst); err != nil {
+	// 1e300 in 'f' format is far longer than maxScratchValueLen.
+	if err := NewEncoder().Encode(S{A: 1, B: 2, C: "3", L: 1e300}, dst); err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(dst["k"], []string{"1", "2"}) || !reflect.DeepEqual(dst["c"], []string{"3"}) {
 		t.Fatalf("got %v", dst)
 	}
-	if !reflect.DeepEqual(dst["l"], []string{long}) {
+	if len(dst["l"]) != 1 || len(dst["l"][0]) <= maxScratchValueLen {
 		t.Fatalf("long value got %v", dst["l"])
 	}
 }

--- a/fastpath_test.go
+++ b/fastpath_test.go
@@ -229,19 +229,25 @@ func TestGenericScalarFallbacks(t *testing.T) {
 }
 
 // Two fields sharing an alias must both land under the key when encoding into
-// a fresh dst (the scratch path's append branch).
+// a fresh dst (the scratch path's append branch), and values longer than
+// maxScratchValueLen must bypass the shared scratch array.
 func TestEncodeDuplicateAliasFreshDst(t *testing.T) {
 	type S struct {
 		A string `schema:"k"`
 		B string `schema:"k"`
 		C string `schema:"c"`
+		L string `schema:"l"`
 	}
+	long := strings.Repeat("x", maxScratchValueLen+1)
 	dst := map[string][]string{}
-	if err := NewEncoder().Encode(S{A: "1", B: "2", C: "3"}, dst); err != nil {
+	if err := NewEncoder().Encode(S{A: "1", B: "2", C: "3", L: long}, dst); err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(dst["k"], []string{"1", "2"}) || !reflect.DeepEqual(dst["c"], []string{"3"}) {
 		t.Fatalf("got %v", dst)
+	}
+	if !reflect.DeepEqual(dst["l"], []string{long}) {
+		t.Fatalf("long value got %v", dst["l"])
 	}
 }
 

--- a/fastpath_test.go
+++ b/fastpath_test.go
@@ -1,0 +1,206 @@
+package schema
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Keys served by the precomputed direct-path map must behave exactly like the
+// generic parser: case-insensitive, covering flat aliases and dotted chains
+// through non-pointer nested structs.
+func TestDirectPathLookup(t *testing.T) {
+	type Inner struct {
+		Value string `schema:"value"`
+	}
+	type Outer struct {
+		Name   string `schema:"name"`
+		Nested Inner  `schema:"nested"`
+	}
+
+	for _, keys := range []struct {
+		name, nested string
+	}{
+		{"name", "nested.value"},
+		{"NAME", "NESTED.VALUE"},
+		{"NaMe", "NeStEd.VaLuE"},
+	} {
+		var s Outer
+		data := map[string][]string{
+			keys.name:   {"x"},
+			keys.nested: {"y"},
+		}
+		if err := NewDecoder().Decode(&s, data); err != nil {
+			t.Fatalf("Decode(%q, %q): %v", keys.name, keys.nested, err)
+		}
+		if s.Name != "x" || s.Nested.Value != "y" {
+			t.Fatalf("Decode(%q, %q) = %+v, want Name=x Nested.Value=y", keys.name, keys.nested, s)
+		}
+	}
+}
+
+// Direct-path entries exist for statically-resolvable keys only; everything
+// else must keep flowing through the generic parser unchanged.
+func TestDirectPathLookupFallbacks(t *testing.T) {
+	// Keys longer than the case-fold buffer take the generic path.
+	longAlias := strings.Repeat("a", maxDirectKeyLen+8)
+	type Long struct {
+		Field string `schema:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`
+	}
+	if len(longAlias) != maxDirectKeyLen+8 {
+		t.Fatal("bad test setup")
+	}
+	var l Long
+	if err := NewDecoder().Decode(&l, map[string][]string{longAlias: {"v"}}); err != nil {
+		t.Fatalf("long key: %v", err)
+	}
+	if l.Field != "v" {
+		t.Fatalf("long key decoded %+v", l)
+	}
+
+	// A bare slice-of-structs alias still needs a slice index; the direct map
+	// must not make it valid.
+	type Item struct {
+		Value string `schema:"value"`
+	}
+	type WithItems struct {
+		Items []Item `schema:"items"`
+	}
+	var w WithItems
+	err := NewDecoder().Decode(&w, map[string][]string{"items": {"x"}})
+	if err == nil {
+		t.Fatal("bare slice-of-structs alias must remain an invalid path")
+	}
+	if _, ok := err.(MultiError)["items"].(UnknownKeyError); !ok {
+		t.Fatalf("want UnknownKeyError, got %v", err)
+	}
+
+	// Pointer-to-struct chains are not precomputed but must keep decoding.
+	type Inner struct {
+		Value string `schema:"value"`
+	}
+	type WithPtr struct {
+		Nested *Inner `schema:"nested"`
+	}
+	var p WithPtr
+	if err := NewDecoder().Decode(&p, map[string][]string{"NESTED.value": {"y"}}); err != nil {
+		t.Fatalf("pointer chain: %v", err)
+	}
+	if p.Nested == nil || p.Nested.Value != "y" {
+		t.Fatalf("pointer chain decoded %+v", p)
+	}
+}
+
+// The native slice decode path must keep the generic path's semantics:
+// comma splitting, zeroEmpty handling, all-or-nothing assignment, and
+// ConversionError details.
+func TestNativeSliceDecode(t *testing.T) {
+	type S struct {
+		Tags   []string  `schema:"tags"`
+		IDs    []int     `schema:"ids"`
+		Scores []float64 `schema:"scores"`
+		Flags  []bool    `schema:"flags"`
+		Big    []int64   `schema:"big"`
+		U      []uint    `schema:"u"`
+		U64    []uint64  `schema:"u64"`
+	}
+
+	var s S
+	data := map[string][]string{
+		"tags":   {"a", "b,c", ""}, // strings never split on commas
+		"ids":    {"1,2", "3"},
+		"scores": {"1.5", "2.5"},
+		"flags":  {"true", "on"},
+		"big":    {"9007199254740993"},
+		"u":      {"7"},
+		"u64":    {"18446744073709551615"},
+	}
+	if err := NewDecoder().Decode(&s, data); err != nil {
+		t.Fatal(err)
+	}
+	want := S{
+		Tags:   []string{"a", "b,c"},
+		IDs:    []int{1, 2, 3},
+		Scores: []float64{1.5, 2.5},
+		Flags:  []bool{true, true},
+		Big:    []int64{9007199254740993},
+		U:      []uint{7},
+		U64:    []uint64{18446744073709551615},
+	}
+	if !reflect.DeepEqual(s, want) {
+		t.Fatalf("got %+v, want %+v", s, want)
+	}
+
+	// zeroEmpty appends zero values for empty items.
+	var z S
+	d := NewDecoder()
+	d.ZeroEmpty(true)
+	if err := d.Decode(&z, map[string][]string{"ids": {"1,,2", ""}}); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(z.IDs, []int{1, 0, 2, 0}) {
+		t.Fatalf("zeroEmpty got %v", z.IDs)
+	}
+
+	// A parse failure must leave the field untouched and carry the value's
+	// index in the ConversionError.
+	pre := S{IDs: []int{42}}
+	err := NewDecoder().Decode(&pre, map[string][]string{"ids": {"1", "oops"}})
+	if err == nil {
+		t.Fatal("want conversion error")
+	}
+	convErr, ok := err.(MultiError)["ids"].(ConversionError)
+	if !ok {
+		t.Fatalf("want ConversionError, got %v", err)
+	}
+	if convErr.Index != 1 {
+		t.Fatalf("want Index=1, got %d", convErr.Index)
+	}
+	if !reflect.DeepEqual(pre.IDs, []int{42}) {
+		t.Fatalf("field must stay untouched on error, got %v", pre.IDs)
+	}
+}
+
+type sliceHeavyStruct struct {
+	Tags   []string  `schema:"tags"`
+	IDs    []int     `schema:"ids"`
+	Scores []float64 `schema:"scores"`
+	Flags  []bool    `schema:"flags"`
+}
+
+func BenchmarkSliceHeavyDecode(b *testing.B) {
+	data := map[string][]string{
+		"tags":   {"alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta", "iota", "kappa", "lambda", "mu", "nu", "xi", "omicron", "pi"},
+		"ids":    {"1,2,3,4,5,6,7,8", "9,10,11,12,13,14,15,16"},
+		"scores": {"1.5", "2.5", "3.5", "4.5", "5.5", "6.5", "7.5", "8.5"},
+		"flags":  {"true", "false", "true", "false", "true", "false", "true", "false"},
+	}
+	decoder := NewDecoder()
+	s := &sliceHeavyStruct{}
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := decoder.Decode(s, data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMixedCaseKeyDecode(b *testing.B) {
+	type S struct {
+		FirstName string `schema:"firstName"`
+		LastName  string `schema:"lastName"`
+		Age       int    `schema:"age"`
+	}
+	data := map[string][]string{
+		"FirstName": {"Grace"},
+		"LASTNAME":  {"Hopper"},
+		"age":       {"85"},
+	}
+	decoder := NewDecoder()
+	s := &S{}
+	for b.Loop() {
+		if err := decoder.Decode(s, data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/fastpath_test.go
+++ b/fastpath_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 )
 
-// Keys served by the precomputed direct-path map must behave exactly like the
-// generic parser: case-insensitive, covering flat aliases and dotted chains
-// through non-pointer nested structs.
+// Keys served by the direct-path map must behave exactly like the generic
+// parser: case-insensitive, covering flat aliases and nested dotted chains.
 func TestDirectPathLookup(t *testing.T) {
 	type Inner struct {
 		Value string `schema:"value"`
@@ -91,9 +90,8 @@ func TestDirectPathLookupFallbacks(t *testing.T) {
 	}
 }
 
-// The native slice decode path must keep the generic path's semantics:
-// comma splitting, zeroEmpty handling, all-or-nothing assignment, and
-// ConversionError details.
+// The native slice decode path must keep the generic path's semantics: comma
+// splitting, zeroEmpty, all-or-nothing assignment, ConversionError details.
 func TestNativeSliceDecode(t *testing.T) {
 	type S struct {
 		Tags   []string  `schema:"tags"`
@@ -180,6 +178,28 @@ func BenchmarkSliceHeavyDecode(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		if err := decoder.Decode(s, data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Unlike the other encode benchmarks, this one encodes into a fresh map each
+// iteration, matching how callers build url.Values per request.
+func BenchmarkEncodeFreshDst(b *testing.B) {
+	type S struct {
+		A string  `schema:"a"`
+		B int     `schema:"b"`
+		C bool    `schema:"c"`
+		D float64 `schema:"d"`
+		E []int   `schema:"e"`
+		F string  `schema:"f,omitempty"`
+	}
+	s := S{A: "abc", B: 123, C: true, D: 3.14, E: []int{1, 2, 3}}
+	enc := NewEncoder()
+	b.ReportAllocs()
+	for b.Loop() {
+		vals := make(map[string][]string, 8)
+		if err := enc.Encode(&s, vals); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/fastpath_test.go
+++ b/fastpath_test.go
@@ -160,6 +160,91 @@ func TestNativeSliceDecode(t *testing.T) {
 	}
 }
 
+// Named slice types take the generic reflect loop, not the native path; its
+// semantics must match the native path's exactly.
+func TestGenericSliceNamedTypes(t *testing.T) {
+	type IDs []int
+	type Tags []string
+	type S struct {
+		IDs  IDs  `schema:"ids"`
+		Tags Tags `schema:"tags"`
+	}
+
+	var s S
+	data := map[string][]string{
+		"ids":  {"1,2", "3"},
+		"tags": {"a", "b,c"},
+	}
+	if err := NewDecoder().Decode(&s, data); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(s.IDs, IDs{1, 2, 3}) || !reflect.DeepEqual(s.Tags, Tags{"a", "b,c"}) {
+		t.Fatalf("got %+v", s)
+	}
+
+	// zeroEmpty fills zero slots; empties are dropped without it.
+	var z S
+	d := NewDecoder()
+	d.ZeroEmpty(true)
+	if err := d.Decode(&z, map[string][]string{"ids": {"1,,2", ""}}); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(z.IDs, IDs{1, 0, 2, 0}) {
+		t.Fatalf("zeroEmpty got %v", z.IDs)
+	}
+	var trunc S
+	if err := NewDecoder().Decode(&trunc, map[string][]string{"ids": {"1,,2", ""}}); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(trunc.IDs, IDs{1, 2}) {
+		t.Fatalf("truncation got %v", trunc.IDs)
+	}
+
+	// Parse failures, both inside a comma list and as a plain value.
+	for _, bad := range []string{"1,x", "x"} {
+		var b S
+		err := NewDecoder().Decode(&b, map[string][]string{"ids": {bad}})
+		if _, ok := err.(MultiError)["ids"].(ConversionError); !ok {
+			t.Fatalf("value %q: want ConversionError, got %v", bad, err)
+		}
+	}
+}
+
+// Fields the fast scalar path skips (pointers) keep their generic behavior.
+func TestGenericScalarFallbacks(t *testing.T) {
+	type S struct {
+		N *int `schema:"n"`
+	}
+
+	// Empty value + ZeroEmpty on a pointer field takes the generic zeroing.
+	d := NewDecoder()
+	d.ZeroEmpty(true)
+	var s S
+	if err := d.Decode(&s, map[string][]string{"n": {""}}); err != nil {
+		t.Fatal(err)
+	}
+	if s.N == nil || *s.N != 0 {
+		t.Fatalf("want zeroed *int, got %+v", s.N)
+	}
+}
+
+// Two fields sharing an alias must both land under the key when encoding into
+// a fresh dst (the scratch path's append branch).
+func TestEncodeDuplicateAliasFreshDst(t *testing.T) {
+	type S struct {
+		A string `schema:"k"`
+		B string `schema:"k"`
+		C string `schema:"c"`
+	}
+	dst := map[string][]string{}
+	if err := NewEncoder().Encode(S{A: "1", B: "2", C: "3"}, dst); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(dst["k"], []string{"1", "2"}) || !reflect.DeepEqual(dst["c"], []string{"3"}) {
+		t.Fatalf("got %v", dst)
+	}
+}
+
 type sliceHeavyStruct struct {
 	Tags   []string  `schema:"tags"`
 	IDs    []int     `schema:"ids"`

--- a/fastpath_test.go
+++ b/fastpath_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 // Keys served by the direct-path map must behave exactly like the generic
@@ -180,6 +181,112 @@ func BenchmarkSliceHeavyDecode(b *testing.B) {
 		if err := decoder.Decode(s, data); err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+type fan0 struct {
+	V string `schema:"v"`
+}
+type fan1 struct {
+	A fan0 `schema:"a"`
+	B fan0 `schema:"b"`
+}
+type fan2 struct {
+	A fan1 `schema:"a"`
+	B fan1 `schema:"b"`
+}
+type fan3 struct {
+	A fan2 `schema:"a"`
+	B fan2 `schema:"b"`
+}
+type fan4 struct {
+	A fan3 `schema:"a"`
+	B fan3 `schema:"b"`
+}
+type fan5 struct {
+	A fan4 `schema:"a"`
+	B fan4 `schema:"b"`
+}
+type fan6 struct {
+	A fan5 `schema:"a"`
+	B fan5 `schema:"b"`
+}
+type fan7 struct {
+	A fan6 `schema:"a"`
+	B fan6 `schema:"b"`
+}
+type fan8 struct {
+	A fan7 `schema:"a"`
+	B fan7 `schema:"b"`
+}
+type fan9 struct {
+	A fan8 `schema:"a"`
+	B fan8 `schema:"b"`
+}
+type fan10 struct {
+	A fan9 `schema:"a"`
+	B fan9 `schema:"b"`
+}
+type fan11 struct {
+	A fan10 `schema:"a"`
+	B fan10 `schema:"b"`
+}
+type fan12 struct {
+	A fan11 `schema:"a"`
+	B fan11 `schema:"b"`
+}
+type fan13 struct {
+	A fan12 `schema:"a"`
+	B fan12 `schema:"b"`
+}
+type fan14 struct {
+	A fan13 `schema:"a"`
+	B fan13 `schema:"b"`
+}
+type fan15 struct {
+	A fan14 `schema:"a"`
+	B fan14 `schema:"b"`
+}
+type fan16 struct {
+	A fan15 `schema:"a"`
+	B fan15 `schema:"b"`
+}
+type fan17 struct {
+	A fan16 `schema:"a"`
+	B fan16 `schema:"b"`
+}
+type fan18 struct {
+	A fan17 `schema:"a"`
+	B fan17 `schema:"b"`
+}
+type fan19 struct {
+	A fan18 `schema:"a"`
+	B fan18 `schema:"b"`
+}
+
+// Deep fan-out nesting has exponentially many dotted paths; the direct map
+// must stay capped so the first Decode neither stalls nor retains huge maps.
+func TestDirectPathsCappedForDeepFanout(t *testing.T) {
+	d := NewDecoder()
+	var s fan19
+	deepKey := strings.Repeat("a.", 10) + strings.Repeat("b.", 9) + "v"
+	data := map[string][]string{deepKey: {"deep"}}
+	done := make(chan error, 1)
+	go func() { done <- d.Decode(&s, data) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("Decode stalled: direct-path precomputation not capped")
+	}
+	if s.A.A.A.A.A.A.A.A.A.A.B.B.B.B.B.B.B.B.B.V != "deep" {
+		t.Fatal("deep key not decoded")
+	}
+	info := d.cache.get(reflect.TypeOf(s))
+	if len(info.direct) > maxDirectPaths+2 {
+		t.Fatalf("direct map has %d entries, want <= %d", len(info.direct), maxDirectPaths+2)
 	}
 }
 


### PR DESCRIPTION
## Summary

Performance pass over the decode and encode hot paths, building on the SWAR/SIMD support in `gofiber/utils` v2.

### 1. Precomputed direct paths with SWAR key folding (`168e2ed`)

- Parsed paths for statically-resolvable keys — flat field aliases and dotted chains through non-pointer nested structs — are precomputed into an immutable per-`structInfo` map at metadata build time. `parsePathInfo` serves these keys with a plain-map probe, bypassing the `sync.Map` path cache, per-segment lowercasing, and path parsing.
- Keys are matched case-insensitively by folding them word-at-a-time with `utils/v2/swar` into a stack buffer (no allocation). Mixed-case keys hitting this path no longer store per-casing clones in the path cache.
- Slice fields typed exactly `[]string`, `[]int`, `[]int64`, `[]uint`, `[]uint64`, `[]float64`, or `[]bool` decode into a native Go slice assigned through the typed field pointer, eliminating `reflect.MakeSlice` and per-element `Index`/`Set` calls. Named slice/element types keep the generic path; semantics (comma splitting, `ZeroEmpty`, all-or-nothing assignment, `ConversionError` details) are unchanged.

### 2. Raw-first probe, fast scalar decode, batched encoder allocations (`a0862f5`)

- The direct-path map is probed with the raw key first (keys are usually already lowercase); the SWAR fold runs only on a miss.
- `fieldInfo` caches a `fastKind` for non-pointer builtin scalar fields with no `TextUnmarshaler` or custom converter, letting `decode` set them directly and skip the converter/unmarshaler dispatch. Converter registration resets the cache, so the build-time decision stays valid.
- Encoding into an empty `dst` map packs single values of distinct keys into one shared backing array (entries capped with three-index slices so later appends reallocate instead of overwriting a neighbor). A non-empty `dst` keeps the previous single-map-op append pattern, so accumulating encodes are unaffected.

### 3. Cap on direct-path precomputation (`ba480b4`)

Deep fan-out nesting has exponentially many dotted chains; uncapped precomputation made the first `Decode` of a depth-18 fan-out-2 type take seconds and retain hundreds of MB. Nested entries are now capped at 512 per struct type (flat aliases are built first and can never be crowded out); keys beyond the cap fall back to the generic parser, which is semantically identical. The reproduction drops to ~16 ms / 0.1 MB retained with no change to hot-path benchmarks.

### 4. Review follow-ups (`36b3f43`, `aed8b34`, `2fa9a1f`)

- Restored coverage of the generic paths the fast paths bypass (named slice types, pointer-scalar `ZeroEmpty`, duplicate-alias encode) and removed an unreachable fallback branch.
- Hardened the encoder scratch against memory retention (raised by Codex review): only strings allocated by this package's own formatters (bool/int/uint/float output, ≤64 bytes) are batched in the shared array — string fields and custom encoder results always get their own independently collectible slice, so a surviving `url.Values` entry can never keep a deleted neighbor's caller-owned allocation alive.

## Benchmarks

Interleaved A/B runs vs `main` (Go 1.25, linux/amd64, benchstat):

| Benchmark | Change |
|---|---|
| SimpleStructDecode | −13% to −20% |
| LargeStructDecode | ~−20% |
| SliceHeavyDecode (new) | ~−20%, fewer B/op |
| EncodeFreshDst (new) | −12%, 7 → 5 allocs/op |
| MixedCaseKeyDecode (new) | fast path, no path-cache growth |
| accumulate-encode, cache-miss, slice-index, multipart | unchanged |

## Verification

- Full test suite passes, including `-race`; `golangci-lint` clean; project coverage 99.2% (patch 100%).
- New regression tests: direct-path case-fold parity (mixed-case flat and nested keys), >64-byte key and pointer-chain fallbacks, bare slice-of-structs aliases staying invalid, native-slice semantics (comma splitting, `ZeroEmpty`, all-or-nothing, `ConversionError` index), a deep fan-out type pinning the precomputation cap, and encoder scratch eligibility branches.
- Extensive differential testing against `main` (case folding incl. non-ASCII and 64-byte boundaries, converter/alias-tag re-registration, embedded/promoted fields, multipart, 32-bit truncation guards, encoder scratch aliasing under recursion and duplicate keys) found no behavioral divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ooKnSP4gG9tAd5rCAkyxZ